### PR TITLE
fix: cache round-trip (#16), bbox shape (#17) + duplicate-column JSON export crash

### DIFF
--- a/api/migrations/0011_alter_extracted_bounding_box.py
+++ b/api/migrations/0011_alter_extracted_bounding_box.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0010_increase_extracted_file_max_length'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='extracted',
+            name='bounding_box',
+            field=models.JSONField(blank=True, help_text='Table location as {x1, y1, x2, y2} coordinates', null=True),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -186,7 +186,7 @@ class Extracted(models.Model):
     bounding_box = models.JSONField(
         null=True,
         blank=True,
-        help_text="Table location as {x0, y0, x1, y1} coordinates",
+        help_text="Table location as {x1, y1, x2, y2} coordinates",
     )
     selection = models.ForeignKey(
         'TableSelection',

--- a/api/scripts/YOLOV3/predict_table.py
+++ b/api/scripts/YOLOV3/predict_table.py
@@ -57,7 +57,7 @@ from PyPDF2 import PdfWriter, PdfReader
 from pdf2image import convert_from_path, convert_from_bytes
 from api.scripts.YOLOV3.utils.detect_func import detectTable, parameters
 from api.scripts.table_detector import detect_table_type_from_array
-from api.scripts.header_processor import process_table_headers, strip_empty_rows_and_cols
+from api.scripts.header_processor import process_table_headers, strip_empty_rows_and_cols, uniquify_column_names
 from api.scripts.extractors import MultiExtractor, VisionExtractor, ExtractionScorer
 from api.scripts.extractors.base import ExtractionResult
 from api.scripts.xlsx_exporter import export_to_xlsx, build_xlsx_structure_from_extraction
@@ -410,7 +410,9 @@ def detect_tables(file_path, page_number, output_type, report_db, extract_dir,
             if key == "csv":
                 table.to_csv(str(e_path), index=False)
             elif key == "json":
-                json_output = json_lib.loads(table.to_json(orient="columns"))
+                # orient='columns' needs unique labels; multi-row header merges
+                # can repeat them (e.g. two 'Total' sub-columns). See #16 review.
+                json_output = json_lib.loads(uniquify_column_names(table).to_json(orient="columns"))
                 json_output['_extraction_metadata'] = {
                     'method': best_variant['method'],
                     'page_num': pg,
@@ -848,7 +850,9 @@ def save_extraction_results(results: List[ExtractionResult], file_path: str,
                 db.to_csv(str(e_path), index=False)
             elif key == "json":
                 # Include extraction method in JSON output (backwards compatible - additive)
-                json_str = db.to_json(orient="columns")
+                # orient='columns' needs unique labels; multi-row header merges
+                # can repeat them (e.g. two 'Total' sub-columns). See #16 review.
+                json_str = uniquify_column_names(db).to_json(orient="columns")
                 json_output = json_lib.loads(json_str)
 
                 # Add extraction metadata (additive - backwards compatible)

--- a/api/scripts/YOLOV3/predict_table.py
+++ b/api/scripts/YOLOV3/predict_table.py
@@ -295,7 +295,9 @@ def detect_tables(file_path, page_number, output_type, report_db, extract_dir,
         if len(coords) == 4:
             x1, y1, x2, y2 = float(coords[0]), float(coords[1]), float(coords[2]), float(coords[3])
             table_areas.append((x1, y1, x2, y2))
-            bounding_boxes.append({'x0': x1, 'y0': y1, 'x1': x2, 'y1': y2})
+            # Canonical bbox shape: {x1, y1, x2, y2}, matching every BaseExtractor
+            # backend's metadata['bounding_box'] and Extracted.bounding_box (issue #17).
+            bounding_boxes.append({'x1': x1, 'y1': y1, 'x2': x2, 'y2': y2})
 
     if not table_areas:
         log.output('INFO', f'Page {pg}: No table areas detected by YOLO')
@@ -362,11 +364,11 @@ def detect_tables(file_path, page_number, output_type, report_db, extract_dir,
         page_height = pdf_page.mediabox.height
 
         # Convert PDF coords to percentage (0-100) for TableSelection
-        x1_pct = (bbox['x0'] / float(page_width)) * 100
-        x2_pct = (bbox['x1'] / float(page_width)) * 100
+        x1_pct = (bbox['x1'] / float(page_width)) * 100
+        x2_pct = (bbox['x2'] / float(page_width)) * 100
         # Y-flip: PDF origin is bottom-left, canvas is top-left
-        y1_pct = (1 - bbox['y1'] / float(page_height)) * 100
-        y2_pct = (1 - bbox['y0'] / float(page_height)) * 100
+        y1_pct = (1 - bbox['y2'] / float(page_height)) * 100
+        y2_pct = (1 - bbox['y1'] / float(page_height)) * 100
         # Ensure valid box: y1 < y2 (top < bottom in screen coords)
         if y1_pct > y2_pct:
             y1_pct, y2_pct = y2_pct, y1_pct

--- a/api/scripts/header_processor.py
+++ b/api/scripts/header_processor.py
@@ -334,6 +334,42 @@ def clean_column_names(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def uniquify_column_names(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Return a copy of ``df`` whose column labels are made unique by suffixing
+    duplicates as ``name``, ``name.1``, ``name.2``, ...
+
+    Multi-row header merging (:func:`merge_header_rows_hierarchical`) can
+    legitimately produce repeated labels — e.g. two ``"Region > Total"``
+    sub-columns. These render fine in CSV/XLSX (positional) but
+    ``DataFrame.to_json(orient="columns")`` requires unique labels (it builds a
+    ``{column: {row: value}}`` dict) and raises ``ValueError`` otherwise. Call
+    this immediately before such a JSON export.
+
+    Columns that are already unique are returned unchanged (the same object, no
+    copy). The suffixing loop is collision-safe even when a synthesized name
+    (e.g. ``"Total.1"``) already exists among the original labels.
+    """
+    cols = [str(c) for c in df.columns]
+    if len(set(cols)) == len(cols):
+        return df
+
+    used = set()
+    unique = []
+    for col in cols:
+        candidate = col
+        suffix = 0
+        while candidate in used:
+            suffix += 1
+            candidate = f"{col}.{suffix}"
+        used.add(candidate)
+        unique.append(candidate)
+
+    out = df.copy()
+    out.columns = unique
+    return out
+
+
 def process_table_headers(df: pd.DataFrame, merge_headers: bool = True,
                           max_header_rows: int = 4) -> tuple:
     """

--- a/api/scripts/table_extract.py
+++ b/api/scripts/table_extract.py
@@ -122,19 +122,19 @@ def _normalize_bbox(bbox: dict) -> tuple:
     """
     Normalize bounding box to (x_min, y_min, x_max, y_max) format.
 
-    Handles different formats:
-    - Camelot/pdfplumber: x0, y0, x1, y1
-    - VisionExtractor: x1, y1, x2, y2
+    All extractor backends emit the canonical ``{x1, y1, x2, y2}`` shape. The
+    legacy ``{x0, y0, x1, y1}`` branch is retained defensively for any older
+    cached/stored payloads predating the issue #17 normalization.
     """
     if not bbox:
         return None
 
-    # Try x0/y0/x1/y1 format first (Camelot)
-    if 'x0' in bbox:
-        return (bbox['x0'], bbox['y0'], bbox['x1'], bbox['y1'])
-    # Try x1/y1/x2/y2 format (VisionExtractor)
-    elif 'x1' in bbox and 'x2' in bbox:
+    # Canonical shape emitted by every extractor backend.
+    if 'x1' in bbox and 'x2' in bbox:
         return (bbox['x1'], bbox['y1'], bbox['x2'], bbox['y2'])
+    # Legacy shape (defensive; no current producer emits this).
+    elif 'x0' in bbox:
+        return (bbox['x0'], bbox['y0'], bbox['x1'], bbox['y1'])
     return None
 
 

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -42,12 +42,31 @@ def _serialize_variants_for_cache(variants: list) -> str:
 
 
 def _deserialize_variants_from_cache(data: str) -> list:
-    """Deserialize extraction variants from cache."""
-    from io import StringIO
+    """Deserialize extraction variants from cache.
+
+    DataFrames are rebuilt directly from the ``orient='split'`` components
+    (columns/index/data) with ``dtype=str`` rather than via ``pd.read_json``.
+    ``read_json``'s type inference silently corrupts the round-trip in two ways
+    (see issue #16):
+
+    - Identifier-like cells lose their exact form ('001' -> 1, '1.50' -> 1.5).
+    - Duplicate column labels get a ``.1`` suffix ('Total','Total' ->
+      'Total','Total.1').
+
+    Each extractor's ``_clean_dataframe`` stringifies cells before they are
+    cached, so forcing ``str`` on the way back reproduces exactly what was
+    extracted instead of re-introducing numeric types.
+    """
     variants = json.loads(data)
     for v in variants:
         if 'dataframe_json' in v:
-            v['dataframe'] = pd.read_json(StringIO(v['dataframe_json']), orient='split')
+            split = json.loads(v['dataframe_json'])
+            v['dataframe'] = pd.DataFrame(
+                data=split['data'],
+                index=split['index'],
+                columns=split['columns'],
+                dtype=str,
+            )
             del v['dataframe_json']
         else:
             v['dataframe'] = None

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -53,9 +53,11 @@ def _deserialize_variants_from_cache(data: str) -> list:
     - Duplicate column labels get a ``.1`` suffix ('Total','Total' ->
       'Total','Total.1').
 
-    Each extractor's ``_clean_dataframe`` stringifies cells before they are
+    Extractor outputs are already string-typed and ``fillna``'d before they are
     cached, so forcing ``str`` on the way back reproduces exactly what was
-    extracted instead of re-introducing numeric types.
+    extracted instead of re-introducing numeric types. Assumes single-level row
+    and column axes (true for every extractor output); MultiIndex axes are not
+    produced in this pipeline and are not handled by this reconstruction.
     """
     variants = json.loads(data)
     for v in variants:

--- a/api/tests/test_header_processor.py
+++ b/api/tests/test_header_processor.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for api/scripts/header_processor.py helpers.
+
+header_processor only depends on pandas/numpy/re, so these run without Django
+or the heavy extractor stack.
+"""
+
+import pandas as pd
+import pytest
+
+from api.scripts.header_processor import uniquify_column_names
+
+
+class TestUniquifyColumnNames:
+    """Tests for uniquify_column_names() — guards the to_json(orient='columns')
+    export against duplicate column labels produced by multi-row header merges
+    (regression for the duplicate-column crash surfaced in the #16 review)."""
+
+    def test_unique_columns_returned_unchanged(self):
+        # Given: a frame whose labels are already unique
+        df = pd.DataFrame([[1, 2, 3]], columns=["a", "b", "c"])
+
+        # When/Then: returned object is the same instance (no copy)
+        assert uniquify_column_names(df) is df
+
+    def test_duplicate_labels_are_suffixed(self):
+        # Given: a multi-row header merge produced two identical labels
+        df = pd.DataFrame([["10", "20"]], columns=["Region > Total", "Region > Total"])
+
+        # When: uniquifying
+        out = uniquify_column_names(df)
+
+        # Then: duplicates get a .1 suffix; data is preserved
+        assert list(out.columns) == ["Region > Total", "Region > Total.1"]
+        assert out.values.tolist() == [["10", "20"]]
+
+    def test_uniquified_frame_serializes_as_columns_json(self):
+        # Given: duplicate columns that crash to_json(orient='columns')
+        df = pd.DataFrame([["10", "20"]], columns=["Total", "Total"])
+        with pytest.raises(ValueError):
+            df.to_json(orient="columns")
+
+        # When/Then: after uniquifying, the export succeeds
+        out = uniquify_column_names(df)
+        json_str = out.to_json(orient="columns")  # must not raise
+        assert "Total" in json_str and "Total.1" in json_str
+
+    def test_synthesized_suffix_collision_is_resolved(self):
+        # Given: a synthesized name ("Total.1") already exists among originals
+        df = pd.DataFrame([[1, 2, 3]], columns=["Total", "Total", "Total.1"])
+
+        # When: uniquifying
+        out = uniquify_column_names(df)
+
+        # Then: all labels are unique (collision-safe loop)
+        assert len(set(out.columns)) == 3
+        assert "Total" in out.columns
+
+    def test_does_not_mutate_input(self):
+        # Given: a frame with duplicate labels
+        df = pd.DataFrame([["x", "y"]], columns=["Dup", "Dup"])
+
+        # When: uniquifying
+        uniquify_column_names(df)
+
+        # Then: the original frame is untouched
+        assert list(df.columns) == ["Dup", "Dup"]

--- a/api/tests/test_multi_result_extraction.py
+++ b/api/tests/test_multi_result_extraction.py
@@ -389,6 +389,45 @@ class TestVariantsCacheSerialization:
         assert deserialized[0]['dataframe'] is None
         assert deserialized[0]['error'] == 'Extraction failed'
 
+    def test_round_trip_preserves_identifier_cell_types(self):
+        """Regression for issue #16: leading zeros and decimal formatting must
+        survive the cache round-trip (read_json would coerce '001'->1, '1.50'->1.5)."""
+        # Given: cells already stringified by an extractor's _clean_dataframe
+        df = pd.DataFrame({
+            'code': ['001', '002', '030'],
+            'price': ['1.50', '2.00', '10.00'],
+        })
+        variants = [{'method': 'camelot_lattice', 'dataframe': df}]
+
+        # When: round-tripping through the cache
+        deserialized = _deserialize_variants_from_cache(
+            _serialize_variants_for_cache(variants)
+        )
+        back = deserialized[0]['dataframe']
+
+        # Then: exact string values are preserved (no numeric coercion)
+        assert back['code'].tolist() == ['001', '002', '030']
+        assert back['price'].tolist() == ['1.50', '2.00', '10.00']
+        assert all(str(dt) == 'object' for dt in back.dtypes)
+
+    def test_round_trip_preserves_duplicate_columns(self):
+        """Regression for issue #16: duplicate column labels must not be renamed
+        (read_json would turn ['Total','Total'] into ['Total','Total.1'])."""
+        # Given: a DataFrame with duplicate column labels
+        df = pd.DataFrame([['a', 'b'], ['c', 'd']], columns=['Total', 'Total'])
+        variants = [{'method': 'pdfplumber', 'dataframe': df}]
+
+        # When: round-tripping through the cache
+        deserialized = _deserialize_variants_from_cache(
+            _serialize_variants_for_cache(variants)
+        )
+        back = deserialized[0]['dataframe']
+
+        # Then: duplicate labels survive unchanged
+        assert list(back.columns) == ['Total', 'Total']
+        assert back.shape == (2, 2)
+        assert back.values.tolist() == [['a', 'b'], ['c', 'd']]
+
 
 # =============================================================================
 # Test API Endpoints (Django TestCase)

--- a/api/tests/test_phase4_e2e.py
+++ b/api/tests/test_phase4_e2e.py
@@ -198,6 +198,20 @@ class TestMetadataFieldsPopulated:
         """detect_tables should populate bounding_box field."""
         assert "bounding_box=" in predict_table_source
 
+    def test_bounding_box_help_text_uses_canonical_shape(self, model_source):
+        """Regression for issue #17: help_text must document the canonical
+        {x1, y1, x2, y2} shape that every extractor backend (and the normalized
+        YOLO/auto path) actually stores."""
+        assert "{x1, y1, x2, y2}" in model_source
+        assert "{x0, y0, x1, y1}" not in model_source
+
+    def test_detect_tables_builds_canonical_bbox_shape(self, predict_table_source):
+        """Regression for issue #17: the YOLO/auto path must build bounding boxes
+        with the canonical {x1, y1, x2, y2} keys, not the legacy {x0, y0, ...}."""
+        assert "{'x1': x1, 'y1': y1, 'x2': x2, 'y2': y2}" in predict_table_source
+        assert "'x0'" not in predict_table_source
+        assert "'y0'" not in predict_table_source
+
     def test_extract_tables_direct_populates_all_fields(self, predict_table_source):
         """extract_tables_direct should populate all rich fields.
 


### PR DESCRIPTION
Three small, backend-agnostic bug fixes — two from the issue tracker, one surfaced (and validated as reachable) during the adversarial review of these fixes. Kept **separate from #15 (Docling)** since they're unrelated to that feature and can merge independently.

## #16 — Variants cache round-trip corrupts cell types / renames duplicate columns
`_deserialize_variants_from_cache` used `pd.read_json(orient='split')`, whose type inference silently:
- coerced identifier-like cells (`'001'`→`1`, `'1.50'`→`1.5`), losing leading zeros/formatting, and
- renamed duplicate columns (`['Total','Total']`→`['Total','Total.1']`).

The switch-method flow reads from this cache, so the displayed/cached table could diverge from what was extracted.

**Fix:** rebuild the DataFrame directly from the `orient='split'` components with `dtype=str`. Cells are already string-typed/`fillna`'d before caching, so this reproduces exactly what was extracted. (The issue's suggested `dtype=str, convert_axes=False` one-liner only fixes the cell-type half — duplicate columns still became `Total.1`, and `orient='table'` mangled them into 4 columns. Direct reconstruction fixes both.)

Closes #16

## #17 — Inconsistent `bounding_box` key shapes + stale help_text
The YOLO/auto path (`detect_tables`) stored `{x0,y0,x1,y1}`, while the `BaseExtractor` backends store `{x1,y1,x2,y2}`; the model `help_text` documented only the YOLO shape.

**Fix:** normalize the YOLO/auto path to canonical `{x1,y1,x2,y2}`; update `Extracted.bounding_box` help_text + add migration `0011`; fix the stale `_normalize_bbox` docstring (legacy branch kept as a defensive fallback).

> **UI-safe:** the web viewer renders from `TableSelection` percentages (loaded via the selections endpoint in `bbox-manager.js`), not from `Extracted.bounding_box` (no serializer even exposes that field). The `TableSelection` percentage math is byte-identical before/after — only stored metadata key names change, so rendered boxes do not move.

Closes #17

## Bonus — Duplicate-column JSON export crash (surfaced + validated in review)
Multi-row header merging (`merge_header_rows_hierarchical`) can legitimately produce **repeated** column labels (e.g. two `'Region > Total'` sub-columns). `DataFrame.to_json(orient='columns')` requires unique labels and raises `ValueError: DataFrame columns must be unique for orient='columns'`. The export loop in `predict_table.py` has no `try/except`, so the table (and its page) failed export.

Confirmed reachable (not just theoretical) from every header-processing path: `detect_tables` (auto/YOLO) and `save_extraction_results` via `extract_tables_direct_readonly` / `extract_tables_vision_readonly`. CSV/XLSX/`structure_json` already tolerate duplicate labels (positional) — only the columns-oriented JSON export was affected.

**Fix:** add `header_processor.uniquify_column_names()` (suffixes dupes `.1`,`.2`, …, collision-safe) and apply it at both `to_json(orient='columns')` sites. CSV/XLSX keep the original repeated labels; only the JSON file disambiguates.

## Adversarial review
One skeptical agent per issue attacked the diagnosis + fix:
- **#17 — UI/web-viewer SAFE** (verified: frontend reads `TableSelection`, not `Extracted.bounding_box`; percentage math byte-identical; mixed old/new DB rows safe).
- **#16 — SOUND** (verified across pandas 2.0.3 / 2.2.3 / 2.3.3; both regression tests genuinely fail on the old code). The review's noted "duplicate-column export" edge is the **Bonus** fix above (investigated → reachable → fixed). The remaining MultiIndex edge stays out of scope (no extractor produces MultiIndex columns).

## ⚠️ Migration note (parallel with #15)
This branch is based on `main`, so the new migration is `0011_alter_extracted_bounding_box` (depends on `0010`). PR #15 also introduces a `0011` + `0012`. **Whichever merges second needs its migration rebased** onto the other (or a `makemigrations --merge`). No code conflict — only the migration graph.

## Testing
- Regression tests: cell-type + duplicate-column cache round-trip (#16); help_text + canonical YOLO bbox shape (#17); `uniquify_column_names` + JSON-export-no-crash (bonus).
- All fixes verified in isolated pandas containers (2.0.3/2.2.3/2.3.3); all edited files compile. Full pytest suite should be run in the project's Docker test env.
